### PR TITLE
fix annotation-document error when creating line

### DIFF
--- a/redLayerModule.py
+++ b/redLayerModule.py
@@ -466,7 +466,7 @@ class redLayer(QgsMapTool):
                 annotation = sketchNoteDialog.newPoint(self.iface, self.geoSketches[midIdx][2].asGeometry())
                 if annotation:
                     self.geoSketches[-1][3] = annotation
-                    self.geoSketches[-1][4] = annotation.document().toPlainText()
+                    self.geoSketches[-1][4] = annotation.annotation().document().toPlainText()
                 self.annotatatedSketch = True
             self.gestures += 1
             self.points = 0


### PR DESCRIPTION
fix to resolve this error when creating an annotation on any line object:

AttributeError: 'QgsMapCanvasAnnotationItem' object has no attribute 'document'
Traceback (most recent call last):
File "/home/<username>/.local/share/QGIS/QGIS3/profiles/default/python/plugins/redLayer/redLayerModule.py", line 478, in canvasPressEvent
self.geoSketches[-1][4] = annotation.document().toPlainText()
^^^^^^^^^^^^^^^^^^^
AttributeError: 'QgsMapCanvasAnnotationItem' object has no attribute 'document'

Python-Version: 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0]
QGIS-Version: 3.44.4-Solothurn Solothurn, 108203c541e